### PR TITLE
Add configs-ignore input

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ The name of a module contains the name of the project and its binary version.
 
 Example: `foo_2.13 bar_2.13`
 
+#### - `configs-ignore` (optional)
+
+A list of space-separated names of configurations to ignore. The action will not submit the dependencies of these configurations.
+
+Example of configurations are `compile`, `test`, `scala-tool`, `scala-doc-tool`.
+
 #### - `token` (optional)
 
 GitHub Personal Access Token (PAT). Defaults to PAT provided by Action runner.
@@ -52,6 +58,8 @@ GitHub Personal Access Token (PAT). Defaults to PAT provided by Action runner.
 Example: `${{ secrets.USER_TOKEN }}`
 
 #### Example
+
+##### Excluding some projects or some Scala versions from the dependency submission.
 
 In this example the snapshot will not contain the graphs of `foo_2.13` and `bar_3`.
 
@@ -65,6 +73,22 @@ steps:
     with:
       base-dir: ./my-scala-project
       modules-ignore: foo_2.13 bar_3
+```
+
+#### Excluding the Scaladoc dependencies.
+
+In this example the snapshot will not contain the dependencies of the scala-doc-tool configuration.
+
+```yaml
+
+## in .github/workflows/dependency-graph.md
+...
+steps:
+  - uses: actions/checkout@v3
+  - uses: scalacenter/sbt-dependency-submission@v2
+    with:
+      base-dir: ./my-scala-project
+      configs-ignore: scala-doc-tool
 ```
 
 ## Troubleshooting

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,12 @@ inputs:
       Example: `foo_2.13 bar_2.13`
     required: false
     default: ''
+  configs-ignore:
+    description: |
+      A list of space-separated names of configurations to ignore. The action will not submit the dependencies of these configurations.
+      Example: `test scala-doc-tool`
+    required: false
+    default: ''
   on-resolve-failure:
     description: |
       Either 'error' or 'warning'.

--- a/sbt-plugin/src/main/contraband/input.contra
+++ b/sbt-plugin/src/main/contraband/input.contra
@@ -16,4 +16,11 @@ type SubmitInput {
   ## The name of module is composed of the name of the project and its binary version.
   ## Example: foo_2.13
   ignoredModules: [String]
+
+  ## A set of sbt configurations to ignore.
+  ## Examples:
+  ##  - "test" to ignore the test dependencies
+  ##  - "scala-doc-tool" to ignore the scaladoc dependencies
+  ##  - "scala-tool" to ignore the compiler dependencies
+  ignoredConfigs: [String]
 }

--- a/sbt-plugin/src/sbt-test/dependency-manifest/ignore-scaladoc/build.sbt
+++ b/sbt-plugin/src/sbt-test/dependency-manifest/ignore-scaladoc/build.sbt
@@ -1,0 +1,55 @@
+import ch.epfl.scala.githubapi.DependencyRelationship
+import ch.epfl.scala.githubapi.DependencyScope
+import ch.epfl.scala.githubapi.Manifest
+import ch.epfl.scala.SubmitInput
+import sjsonnew.shaded.scalajson.ast.unsafe.JString
+
+val checkScaladoc = taskKey[Unit]("Check scaladoc_3 is in the manifest ")
+val ignoreScaladoc = taskKey[StateTransform]("Ignore the scala-doc-tool in the submit input")
+val checkIgnoreScaladoc = taskKey[Unit]("Check scaladoc_3 is absent in the manifest")
+
+inThisBuild(
+  Seq(
+    organization := "ch.epfl.scala",
+    version := "1.2.0-SNAPSHOT",
+    scalaVersion := "3.2.1"
+  )
+)
+
+Global / ignoreScaladoc := {
+  val input = SubmitInput(None, Vector.empty, ignoredConfigs = Vector("scala-doc-tool"))
+  StateTransform(state => state.put(githubSubmitInputKey, input))
+}
+
+lazy val p1 = project
+  .in(file("p1"))
+  .settings(
+    checkScaladoc := {
+      val manifest = githubDependencyManifest.value.get
+      checkDependency(manifest, "org.scala-lang:scaladoc_3:3.2.1")(
+        expectedRelationship = DependencyRelationship.direct,
+        expectedScope = DependencyScope.development,
+        expectedConfig = "scala-doc-tool"
+      )
+    },
+    checkIgnoreScaladoc := {
+      val manifest = githubDependencyManifest.value.get
+      val suspicious = manifest.resolved.keys.filter(dep => dep.contains("scaladoc_3"))
+      assert(suspicious.isEmpty, s"The manifest should not contain scaladoc_3, found ${suspicious.mkString(", ")}")
+    }
+  )
+
+def checkDependency(manifest: Manifest, name: String)(
+    expectedRelationship: DependencyRelationship = DependencyRelationship.direct,
+    expectedScope: DependencyScope = DependencyScope.runtime,
+    expectedConfig: String = "compile",
+    expectedDeps: Seq[String] = Seq.empty
+): Unit = {
+  val node = manifest.resolved(name)
+  assert(node.package_url.startsWith("pkg:maven/"), s"Wrong package_url for node $name: ${node.package_url}")
+  assert(node.relationship.contains(expectedRelationship), s"Wrong relationship for node $name: ${node.relationship}")
+  assert(node.scope.contains(expectedScope), s"Wrong scope for node $name: ${node.scope}")
+  val configurations = node.metadata.get("config").collect { case JString(c) => c }
+  assert(configurations.contains(expectedConfig), s"Wrong config in metadata for node $name: $configurations")
+  expectedDeps.foreach(d => assert(node.dependencies.contains(d), s"missing dependency $d in node $name"))
+}

--- a/sbt-plugin/src/sbt-test/dependency-manifest/ignore-scaladoc/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/dependency-manifest/ignore-scaladoc/project/plugins.sbt
@@ -1,0 +1,3 @@
+val pluginVersion = sys.props("plugin.version")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-github-dependency-submission" % pluginVersion)

--- a/sbt-plugin/src/sbt-test/dependency-manifest/ignore-scaladoc/test
+++ b/sbt-plugin/src/sbt-test/dependency-manifest/ignore-scaladoc/test
@@ -1,0 +1,3 @@
+> p1 / checkScaladoc
+> Global / ignoreScaladoc
+> p1 / checkIgnoreScaladoc

--- a/sbt-plugin/src/test/scala/ch/epfl/scala/JsonProtocolTests.scala
+++ b/sbt-plugin/src/test/scala/ch/epfl/scala/JsonProtocolTests.scala
@@ -30,7 +30,7 @@ class JsonProtocolTests extends FunSuite {
     import ch.epfl.scala.JsonProtocol._
     val raw = Parser.parseUnsafe("{}")
     val obtained = Converter.fromJson[SubmitInput](raw).get
-    val expected = SubmitInput(None, Vector.empty)
+    val expected = SubmitInput(None, Vector.empty, Vector.empty)
     assertEquals(obtained, expected)
   }
 
@@ -38,7 +38,7 @@ class JsonProtocolTests extends FunSuite {
     import ch.epfl.scala.JsonProtocol._
     val raw = Parser.parseUnsafe("""{"onResolveFailure": "warning"}""")
     val obtained = Converter.fromJson[SubmitInput](raw).get
-    val expected = SubmitInput(Some(OnFailure.warning), Vector.empty)
+    val expected = SubmitInput(Some(OnFailure.warning), Vector.empty, Vector.empty)
     assertEquals(obtained, expected)
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,11 @@ async function run(): Promise<void> {
       .split(' ')
       .filter(value => value.length > 0)
 
+    const ignoredConfigs = core
+      .getInput('configs-ignore')
+      .split(' ')
+      .filter(value => value.length > 0)
+
     const onResolveFailure = core.getInput('on-resolve-failure')
     if (!['error', 'warning'].includes(onResolveFailure)) {
       core.setFailed(
@@ -43,7 +48,7 @@ async function run(): Promise<void> {
       return
     }
 
-    const input = { ignoredModules, onResolveFailure }
+    const input = { ignoredModules, ignoredConfigs, onResolveFailure }
 
     process.env['GITHUB_TOKEN'] = token
     await cli.exec('sbt', [`githubSubmitDependencyGraph ${JSON.stringify(input)}`], {


### PR DESCRIPTION
Fix #49

Add `configs-ignore` input to exclude some sbt configurations from the graphs of dependencies.

This is useful to ignore the Scaladoc dependencies brought by the `scala-doc-tool` configuration.