### PR TITLE
Adding additional sbt parameters options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ GitHub Personal Access Token (PAT). Defaults to PAT provided by Action runner.
 
 Example: `${{ secrets.USER_TOKEN }}`
 
+#### - `additional-sbt-parameters`
+
+Additional parameters to be able to be past to sbt. Defaults to nothing.
+
+Example - `-DsuperCoolRepository.user=${{env.someUsername}} -DsettingYouNeed=ValueYouNeed`
+
 #### Example
 
 ##### Excluding some projects or some Scala versions from the dependency submission.
@@ -89,6 +95,22 @@ steps:
     with:
       working-directory: ./my-scala-project
       configs-ignore: scala-doc-tool
+```
+
+#### Passing additional sbt parameters.
+
+In this example you are passing some specific parameters to sbt.
+
+```yaml
+
+## in .github/workflows/dependency-graph.md
+...
+steps:
+  - uses: actions/checkout@v3
+  - uses: scalacenter/sbt-dependency-submission@v2
+    with:
+      working-directory: ./my-scala-project
+      additional-sbt-parameters: -DsomeRepository.user=programmerman -DsomeNeededSetting=cool
 ```
 
 ## Troubleshooting

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,12 @@ inputs:
       If 'warning', the job will ignore the failing modules and submit the snapshot.
     required: false
     default: error
+  additional-sbt-parameters:
+    description: |
+     Add additional parameters to pass to the sbt command.
+     Can be used for example for repository settings, or parameters needed for your repository.
+    required: false
+    default: ''
   token:
     description: GitHub Personal Access Token (PAT). Defaults to PAT provided by Action runner.
     required: false

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,13 @@ async function run(): Promise<void> {
       .split(' ')
       .filter(value => value.length > 0)
 
+    const additionalSbtParameters = core
+      .getInput('additional-sbt-parameters')
+      .split(' ')
+      .filter(value => value.length > 0)
+
+    const sbtCommand = ['sbt'].concat(additionalSbtParameters).join(' ')
+
     const onResolveFailure = core.getInput('on-resolve-failure')
     if (!['error', 'warning'].includes(onResolveFailure)) {
       core.setFailed(
@@ -49,7 +56,7 @@ async function run(): Promise<void> {
     const input = { ignoredModules, ignoredConfigs, onResolveFailure }
 
     process.env['GITHUB_TOKEN'] = token
-    await cli.exec('sbt', [`githubSubmitDependencyGraph ${JSON.stringify(input)}`], {
+    await cli.exec(sbtCommand, [`githubSubmitDependencyGraph ${JSON.stringify(input)}`], {
       cwd: workingDir,
     })
   } catch (error) {


### PR DESCRIPTION
Hi!

I would love to use the plugin for a project that requires to pass some properties
to sbt to allow access to a repository.

So after exploring the workflow i made up a pull request to add a 'additional-sbt-parameters' options
this would append the options after the `sbt` command.

I have yet to test it for a internal repository (i need to request being able to use my local fork)
but i figured to at least share my work already with this pr.

Kind regards,

Willmar