### PR TITLE
feat: add submission ID and URL as action outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,17 @@ jobs:
     - run: npm run all
     - name: Run sbt-dependency-submission
       uses: ./
+      id: dependency-submission
       with:
         working-directory: sbt-plugin
         sbt-plugin-version: 2.2.0-SNAPSHOT
+    - name: Check outputs
+      run: |
+        echo ${{ steps.dependency-submission.outputs.submission-id }}
+        echo ${{ steps.dependency-submission.outputs.submission-api-url }}
+        echo ${{ steps.dependency-submission.outputs.snapshot-json-path }}
+    - name: Log snapshot JSON
+      run: |
+        cat ${{ steps.dependency-submission.outputs.snapshot-json-path }} | jq
 
         

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,9 @@ Thumbs.db
 # Ignore built ts files
 __tests__/runner/*
 lib/**/*
+
+# Scala
+.bloop/
+.metals/
+metals.sbt
+target/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Once the snapshot of the dependencies has been submitted, GitHub responds with a
 
 The API URL of the submission created by the action. It can be queried to get the submitted snapshot.
 
+#### `snapshot-json-path`
+
+Path to the temporary JSON file with the dependency snapshot that has been submitted.
+
 #### Example
 
 ##### Excluding some projects or some Scala versions from the dependency submission.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ GitHub Personal Access Token (PAT). Defaults to PAT provided by Action runner.
 
 Example: `${{ secrets.USER_TOKEN }}`
 
+### Outputs
+
+#### `submission-id`
+
+Once the snapshot of the dependencies has been submitted, GitHub responds with an ID of this snapshot.
+
+#### `submission-api-url`
+
+The API URL of the submission created by the action. It can be queried to get the submitted snapshot.
+
 #### Example
 
 ##### Excluding some projects or some Scala versions from the dependency submission.
@@ -133,7 +143,3 @@ permissions:
 ### sbt.librarymanagement.ResolveException: Error downloading
 
 This error may happen when you try to access artifacts from private GitHub packages with the default GitHub token. You need to pass personal access token which is allowed to access private packages in the `token` input.
-
-
-
-

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,11 @@ inputs:
     description: Version of the sbt plugin to use.
     required: false
     default: '2.1.2'
+outputs:
+  submission-id:
+    description: The ID of the submission created by the action
+  submission-api-url:
+    description: The URL of the submission created by the action
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,8 @@ outputs:
     description: The ID of the submission created by the action
   submission-api-url:
     description: The URL of the submission created by the action
+  snapshot-json-path:
+    description: The path of the snapshot JSON file created by the action
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/sbt-plugin/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
+++ b/sbt-plugin/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
@@ -83,7 +83,7 @@ object SubmitDependencyGraph {
 
     val snapshotJson = CompactPrinter(Converter.toJsonUnsafe(snapshot))
 
-    val snapshotJsonFile = IO.withTemporaryFile("dependency-snapshot-", ".json") { file =>
+    val snapshotJsonFile = IO.withTemporaryFile("dependency-snapshot-", ".json", keepFile = true) { file =>
       IO.write(file, snapshotJson)
       state.log.info(s"Dependency snapshot written to ${file.getAbsolutePath}")
       file


### PR DESCRIPTION
This addresses some part of the intent described in #112. I didn't have time to delve into the plugin internals to fully address that feature request, but instead opted for this minimal change which allows a subsequent action to use the API endpoint to retrieve the snapshot of dependencies and work with it.