### PR TITLE
Run SBT in batch mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,7 @@ async function run(): Promise<void> {
     const input = { ignoredModules, ignoredConfigs, onResolveFailure }
 
     process.env['GITHUB_TOKEN'] = token
-    await cli.exec('sbt', [`githubSubmitDependencyGraph ${JSON.stringify(input)}`], {
+    await cli.exec('sbt', ['--batch', `githubSubmitDependencyGraph ${JSON.stringify(input)}`], {
       cwd: workingDir,
     })
   } catch (error) {


### PR DESCRIPTION
If an SBT project definition doesn't load, the build hangs on the SBT retry prompt, until it times out after a default six hours.  `cli.exec` doesn't detect that SBT isn't running in an interactive terminal, so we explicitly set it to `--batch` mode.