### PR TITLE
Dogfooding use together with Dependency Review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,4 +76,15 @@ jobs:
       run: |
         cat ${{ steps.dependency-submission.outputs.snapshot-json-path }} | jq
 
-        
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # for comment-summary-in-pr
+    needs: test-action
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v3
+        with:
+          comment-summary-in-pr: always


### PR DESCRIPTION
## What

Verifies this action works together with Dependency Review, as per:
- https://github.com/scalacenter/sbt-dependency-submission/issues/135
- https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review
- https://github.com/actions/dependency-review-action

## Why

- To serve as an example of how to do this.
- To keep knowing that it works together over time.