### PR TITLE
Remove empty line in SubmitDependencyGraph imports

### DIFF
--- a/sbt-plugin/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
+++ b/sbt-plugin/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
@@ -15,7 +15,6 @@ import ch.epfl.scala.githubapi.JsonProtocol._
 import ch.epfl.scala.githubapi._
 import gigahorse.FullResponse
 import gigahorse.HttpClient
-
 import gigahorse.support.asynchttpclient.Gigahorse
 import sbt._
 import sbt.internal.util.complete._


### PR DESCRIPTION
I've noticed that in the PR #145 I've added a empty line by mistake and now that is causing scalafix test to fail.

This PR is to correct that mistake