### PR TITLE
Update to Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,5 +45,5 @@ outputs:
   snapshot-json-path:
     description: The path of the snapshot JSON file created by the action
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 16 is EOL: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Fix #157 