### PR TITLE
docs/fix: explictly install sbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: sbt/setup-sbt@v1
       - uses: scalacenter/sbt-dependency-submission@v2
 ```
 


### PR DESCRIPTION
`ubuntu-latest` no longer contains sbt, so install it explicitly

https://github.com/actions/runner-images/issues/10788#issuecomment-2506148615