### PR TITLE
Override the `ref`, `sha` and the manifests' `source_location` attributes in the JSON that will be submitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Typically you would specify the correlator in a matrix-based job like this:
   correlator: ${{ github.job }}-${{ matrix.directory }}
 ```
 
+#### - `sha-override` (optional)
+
+Overrides the `sha` attribute in the generated JSON file before submission.
+
 #### - `ref-override` (optional)
 
 Overrides the `ref` attribute in the generated JSON file before submission.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Overrides the `sha` attribute in the generated JSON file before submission.
 
 Overrides the `ref` attribute in the generated JSON file before submission.
 
+#### - `manifest-override` (optional)
+
+Overrides the `source_location` attribute of each `file` object in the manifest entries of the JSON file before submission.
+This does not affect which `build.sbt` file is actually processed - that can be controlled by the `working-directory` input.
+
 #### - `token` (optional)
 
 GitHub Personal Access Token (PAT). Defaults to PAT provided by Action runner.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Typically you would specify the correlator in a matrix-based job like this:
   correlator: ${{ github.job }}-${{ matrix.directory }}
 ```
 
+#### - `ref-override` (optional)
+
+Overrides the `ref` attribute in the generated JSON file before submission.
+
 #### - `token` (optional)
 
 GitHub Personal Access Token (PAT). Defaults to PAT provided by Action runner.

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
       If 'warning', the job will ignore the failing modules and submit the snapshot.
     required: false
     default: error
+  ref-override:
+    description: "Overrides the `ref` attribute in the generated JSON file before submission."
+    required: false
+    default: ''
   token:
     description: GitHub Personal Access Token (PAT). Defaults to PAT provided by Action runner.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,10 @@ inputs:
       If 'warning', the job will ignore the failing modules and submit the snapshot.
     required: false
     default: error
+  sha-override:
+    description: "Overrides the `sha` attribute in the generated JSON file before submission."
+    required: false
+    default: ''
   ref-override:
     description: "Overrides the `ref` attribute in the generated JSON file before submission."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,12 @@ inputs:
     description: "Overrides the `ref` attribute in the generated JSON file before submission."
     required: false
     default: ''
+  manifest-override:
+    description: |
+      Overrides the `source_location` attribute of each `file` object in the manifest entries of the JSON file before submission.
+      This does not affect which `build.sbt` file is actually processed - that can be controlled by the `working-directory` input.
+    required: false
+    default: ''
   token:
     description: GitHub Personal Access Token (PAT). Defaults to PAT provided by Action runner.
     required: false

--- a/sbt-plugin/src/main/contraband/input.contra
+++ b/sbt-plugin/src/main/contraband/input.contra
@@ -27,6 +27,9 @@ type DependencySnapshotInput {
   ## The job correlator of the snapshot
   correlator: String
 
+  ## Overrides the sha attribute in the generated JSON file before submission.
+  shaOverride: String
+
   ## Overrides the ref attribute in the generated JSON file before submission.
   refOverride: String
 }

--- a/sbt-plugin/src/main/contraband/input.contra
+++ b/sbt-plugin/src/main/contraband/input.contra
@@ -26,4 +26,7 @@ type DependencySnapshotInput {
 
   ## The job correlator of the snapshot
   correlator: String
+
+  ## Overrides the ref attribute in the generated JSON file before submission.
+  refOverride: String
 }

--- a/sbt-plugin/src/main/contraband/input.contra
+++ b/sbt-plugin/src/main/contraband/input.contra
@@ -32,4 +32,8 @@ type DependencySnapshotInput {
 
   ## Overrides the ref attribute in the generated JSON file before submission.
   refOverride: String
+
+  ## Overrides the source_location attribute of each file object in the manifest entries of the JSON file before submission.
+  ## This does not affect which build.sbt file is actually processed - that can be controlled by the working-directory input.
+  manifestOverride: String
 }

--- a/sbt-plugin/src/main/scala/ch/epfl/scala/GithubDependencyGraphPlugin.scala
+++ b/sbt-plugin/src/main/scala/ch/epfl/scala/GithubDependencyGraphPlugin.scala
@@ -127,6 +127,7 @@ object GithubDependencyGraphPlugin extends AutoPlugin {
 
     val onResolveFailure = inputOpt.flatMap(_.onResolveFailure)
     val ignoredConfigs = inputOpt.toSeq.flatMap(_.ignoredConfigs).toSet
+    val manifestOverrideOpt = inputOpt.flatMap(_.manifestOverride).filterNot(_.trim.isEmpty)
     val moduleName = crossVersion(projectID).name
 
     // a reverse view of internalConfigurationMap (internal-test -> test)
@@ -205,7 +206,12 @@ object GithubDependencyGraphPlugin extends AutoPlugin {
 
         val projectModuleRef = getReference(projectID)
         val metadata = Map("baseDirectory" -> JString(baseDirectory.toString))
-        val manifest = githubapi.Manifest(projectModuleRef, buildFileOpt, metadata, resolved.toMap)
+        val manifest = githubapi.Manifest(
+          projectModuleRef,
+          manifestOverrideOpt.map(githubapi.FileInfo(_)).orElse(buildFileOpt),
+          metadata,
+          resolved.toMap
+        )
         Some(manifest)
     }
   }

--- a/sbt-plugin/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
+++ b/sbt-plugin/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
@@ -42,7 +42,8 @@ object SubmitDependencyGraph {
   private def inputParser(state: State): Parser[DependencySnapshotInput] =
     Parsers.any.*.map { raw =>
       val rawString = raw.mkString
-      if (rawString.isEmpty) DependencySnapshotInput(None, Vector.empty, Vector.empty, Some(""), Some(""))
+      if (rawString.isEmpty)
+        DependencySnapshotInput(None, Vector.empty, Vector.empty, Some(""), Some(""), Some(""))
       else
         JsonParser
           .parseFromString(rawString)
@@ -156,11 +157,12 @@ object SubmitDependencyGraph {
     val scanned = Instant.now
     val manifests = state.get(githubManifestsKey).get
     val inputOpt = state.get(githubSnapshotInputKey)
+    val shaOverrideOpt = inputOpt.flatMap(_.shaOverride).filterNot(_.trim.isEmpty)
     val refOverrideOpt = inputOpt.flatMap(_.refOverride).filterNot(_.trim.isEmpty)
     DependencySnapshot(
       0,
       githubJob(correlator),
-      githubSha(),
+      shaOverrideOpt.getOrElse(githubSha()),
       refOverrideOpt.getOrElse(githubRef()),
       detector,
       Map.empty[String, JValue],

--- a/sbt-plugin/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
+++ b/sbt-plugin/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
@@ -43,7 +43,7 @@ object SubmitDependencyGraph {
     Parsers.any.*.map { raw =>
       val rawString = raw.mkString
       if (rawString.isEmpty)
-        DependencySnapshotInput(None, Vector.empty, Vector.empty, Some(""), Some(""), Some(""))
+        DependencySnapshotInput(None, Vector.empty, Vector.empty, Some(""), Some(""), Some(""), Some(""))
       else
         JsonParser
           .parseFromString(rawString)

--- a/sbt-plugin/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
+++ b/sbt-plugin/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
@@ -42,7 +42,7 @@ object SubmitDependencyGraph {
   private def inputParser(state: State): Parser[DependencySnapshotInput] =
     Parsers.any.*.map { raw =>
       val rawString = raw.mkString
-      if (rawString.isEmpty) DependencySnapshotInput(None, Vector.empty, Vector.empty, Some(""))
+      if (rawString.isEmpty) DependencySnapshotInput(None, Vector.empty, Vector.empty, Some(""), Some(""))
       else
         JsonParser
           .parseFromString(rawString)
@@ -155,11 +155,13 @@ object SubmitDependencyGraph {
     )
     val scanned = Instant.now
     val manifests = state.get(githubManifestsKey).get
+    val inputOpt = state.get(githubSnapshotInputKey)
+    val refOverrideOpt = inputOpt.flatMap(_.refOverride).filterNot(_.trim.isEmpty)
     DependencySnapshot(
       0,
       githubJob(correlator),
       githubSha(),
-      githubRef(),
+      refOverrideOpt.getOrElse(githubRef()),
       detector,
       Map.empty[String, JValue],
       manifests,

--- a/sbt-plugin/src/sbt-test/dependency-manifest/ignore-scaladoc/build.sbt
+++ b/sbt-plugin/src/sbt-test/dependency-manifest/ignore-scaladoc/build.sbt
@@ -17,7 +17,15 @@ inThisBuild(
 )
 
 Global / ignoreScaladoc := {
-  val input = DependencySnapshotInput(None, Vector.empty, ignoredConfigs = Vector("scala-doc-tool"), correlator = None)
+  val input = DependencySnapshotInput(
+    None,
+    Vector.empty,
+    ignoredConfigs = Vector("scala-doc-tool"),
+    correlator = None,
+    shaOverride = None,
+    refOverride = None,
+    manifestOverride = None
+  )
   StateTransform(state => state.put(githubSnapshotInputKey, input))
 }
 

--- a/sbt-plugin/src/sbt-test/dependency-manifest/ignore-test/build.sbt
+++ b/sbt-plugin/src/sbt-test/dependency-manifest/ignore-test/build.sbt
@@ -17,7 +17,15 @@ inThisBuild(
 )
 
 Global / ignoreTestConfig := {
-  val input = DependencySnapshotInput(None, Vector.empty, ignoredConfigs = Vector("test"), correlator = None)
+  val input = DependencySnapshotInput(
+    None,
+    Vector.empty,
+    ignoredConfigs = Vector("test"),
+    correlator = None,
+    shaOverride = None,
+    refOverride = None,
+    manifestOverride = None
+  )
   StateTransform(state => state.put(githubSnapshotInputKey, input))
 }
 

--- a/sbt-plugin/src/test/scala/ch/epfl/scala/JsonProtocolTests.scala
+++ b/sbt-plugin/src/test/scala/ch/epfl/scala/JsonProtocolTests.scala
@@ -30,7 +30,7 @@ class JsonProtocolTests extends FunSuite {
     import ch.epfl.scala.JsonProtocol._
     val raw = Parser.parseUnsafe("{}")
     val obtained = Converter.fromJson[DependencySnapshotInput](raw).get
-    val expected = DependencySnapshotInput(None, Vector.empty, Vector.empty, None)
+    val expected = DependencySnapshotInput(None, Vector.empty, Vector.empty, None, None, None, None)
     assertEquals(obtained, expected)
   }
 
@@ -38,7 +38,7 @@ class JsonProtocolTests extends FunSuite {
     import ch.epfl.scala.JsonProtocol._
     val raw = Parser.parseUnsafe("""{"onResolveFailure": "warning"}""")
     val obtained = Converter.fromJson[DependencySnapshotInput](raw).get
-    val expected = DependencySnapshotInput(Some(OnFailure.warning), Vector.empty, Vector.empty, None)
+    val expected = DependencySnapshotInput(Some(OnFailure.warning), Vector.empty, Vector.empty, None, None, None, None)
     assertEquals(obtained, expected)
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,6 +57,8 @@ async function run(): Promise<void> {
 
     const refOverride = core.getInput('ref-override')
 
+    const manifestOverride = core.getInput('manifest-override')
+
     const input = {
       ignoredModules,
       ignoredConfigs,
@@ -64,6 +66,7 @@ async function run(): Promise<void> {
       correlator,
       shaOverride,
       refOverride,
+      manifestOverride,
     }
 
     if (github.context.eventName === 'pull_request') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,15 @@ async function run(): Promise<void> {
       ? correlatorInput
       : `${github.context.workflow}_${github.context.job}_${github.context.action}`
 
-    const input = { ignoredModules, ignoredConfigs, onResolveFailure, correlator }
+    const refOverride = core.getInput('ref-override')
+
+    const input = {
+      ignoredModules,
+      ignoredConfigs,
+      onResolveFailure,
+      correlator,
+      refOverride,
+    }
 
     if (github.context.eventName === 'pull_request') {
       core.info('pull request, resetting sha')

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,8 @@ async function run(): Promise<void> {
       ? correlatorInput
       : `${github.context.workflow}_${github.context.job}_${github.context.action}`
 
+    const shaOverride = core.getInput('sha-override')
+
     const refOverride = core.getInput('ref-override')
 
     const input = {
@@ -60,6 +62,7 @@ async function run(): Promise<void> {
       ignoredConfigs,
       onResolveFailure,
       correlator,
+      shaOverride,
       refOverride,
     }
 


### PR DESCRIPTION
These inputs do not change how dependencies are processed. They only override certain attributes just before the JSON file is submitted.

By allowing these settings to be overridden, we can implement a workaround to submit dependencies from any branch and have them processed by GitHub - including receiving alerts for them - not just the main branch, which is currently the only officially supported branch.